### PR TITLE
Support for opencv4.1.1

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -43,7 +43,7 @@ set_target_properties(${LIBNAME} PROPERTIES          # create *nix style library
 )
 
 target_link_libraries(${LIBNAME} PUBLIC opencv_core)
-target_link_libraries(${LIBNAME} PRIVATE opencv_imgproc opencv_calib3d opencv_features2d opencv_ml)
+target_link_libraries(${LIBNAME} PRIVATE opencv_imgproc opencv_calib3d opencv_features2d opencv_ml opencv_highgui)
 
 INSTALL(TARGETS ${LIBNAME}
     RUNTIME DESTINATION bin COMPONENT main			# Install the dll file in bin directory

--- a/src/markerdetector.cpp
+++ b/src/markerdetector.cpp
@@ -438,7 +438,7 @@ vector< MarkerDetector::MarkerCandidate> MarkerDetector::thresholdAndDetectRecta
 //#define _aruco_debug_detectrectangles
 #ifdef _aruco_debug_detectrectangles
      cv::Mat simage;
-     cv::cvtColor(input,simage,cv::GRAY2BGR);
+     cv::cvtColor(input,simage,cv::COLOR_GRAY2BGR);
 #endif
 
     /// for each contour, analyze if it is a paralelepiped likely to be the marker
@@ -781,7 +781,7 @@ void MarkerDetector::detect(const cv::Mat& input, vector<Marker>& detectedMarker
         _debug_exec(10,//only executes when compiled in DEBUG mode if debug level is at least 10
                     //show the thresholded images
                     cv::Mat imrect;
-                cv::cvtColor(imgToBeThresHolded,imrect,cv::GRAY2BGR);
+                cv::cvtColor(imgToBeThresHolded,imrect,cv::COLOR_GRAY2BGR);
         for(auto m: MarkerCanditates )
             m.draw(imrect,cv::Scalar(0,245,0));
         cv::imshow("rect-nofiltered",imrect);
@@ -794,7 +794,7 @@ void MarkerDetector::detect(const cv::Mat& input, vector<Marker>& detectedMarker
         _debug_exec(10,//only executes when compiled in DEBUG mode if debug level is at least 10
                     //show the thresholded images
                     cv::Mat imrect;
-                cv::cvtColor(imgToBeThresHolded,imrect,cv::GRAY2BGR);
+                cv::cvtColor(imgToBeThresHolded,imrect,cv::COLOR_GRAY2BGR);
         for(auto m: MarkerCanditates)
             m.draw(imrect,cv::Scalar(0,245,0));
         cv::imshow("rect-filtered",imrect);


### PR DESCRIPTION
It seems for opencv 4.1.1 the cvtcolor argument for the index of the conversion has changed from GRAY2BGR to COLOR_GRAY2BGR. Also it seems now it needs opencv_highgui library for imshow, namedwindow and waitkey.